### PR TITLE
Numeric edition as superscript

### DIFF
--- a/musikwissenschaftliches-arbeiten-gardner-springfeld.csl
+++ b/musikwissenschaftliches-arbeiten-gardner-springfeld.csl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style class="note" version="1.0" demote-non-dropping-particle="never" xmlns="http://purl.org/net/xbiblio/csl">
+<style class="note" version="1.0" demote-non-dropping-particle="never"
+    xmlns="http://purl.org/net/xbiblio/csl">
     <!-- CSL description -->
     <info>
         <title>Musikwissenschaftliches Arbeiten Gardner/Springfeld</title>
@@ -165,7 +166,14 @@
             <if type="chapter book entry-dictionary entry-encyclopedia">
                 <group delimiter=", ">
                     <text macro="book-journal-title"/>
-                    <text variable="edition"/>
+
+                    <!-- non-numeric edition, e.g. "zweite und verbesserte Auflage" -->
+                    <choose>
+                        <if is-numeric="edition" />
+                        <else>
+                            <text variable="edition"/>
+                        </else>
+                    </choose>
                     <text macro="editor"/>
                     <choose>
                         <if variable="volume">
@@ -177,7 +185,15 @@
                     </choose>
                     <group delimiter=" ">
                         <text variable="publisher-place"/>
-                        <text macro="issued-year"/>
+
+                        <group>
+                            <choose>
+                                <if is-numeric="edition">
+                                    <text variable="edition" vertical-align="sup" />
+                                </if>
+                            </choose>
+                            <text macro="issued-year"/>
+                        </group>
                     </group>
                     <text variable="note"/>
                 </group>
@@ -347,7 +363,7 @@
                         <else-if position="ibid">
                             <text term="ibid"/>
                         </else-if>
-                       <else-if position="subsequent">
+                        <else-if position="subsequent">
                             <text macro="author"/>
                             <choose>
                                 <if variable="title-short">


### PR DESCRIPTION
This displays the edition as superscript to the year, while leaving it at its place if it is non-numeric.

@thomasxhua 