### PR TITLE
Leverage is-numeric for volume and page numbers

### DIFF
--- a/musikwissenschaftliches-arbeiten-gardner-springfeld.csl
+++ b/musikwissenschaftliches-arbeiten-gardner-springfeld.csl
@@ -128,10 +128,17 @@
         </date>
     </macro>
     <macro name="page-count">
-        <group delimiter=" ">
-            <text term="page" form="short"/>
-            <text variable="page"/>
-        </group>
+        <choose>
+            <if is-numeric="page">
+                <group delimiter=" ">
+                    <text term="page" form="short"/>
+                    <text variable="page"/>
+                </group>
+            </if>
+            <else>
+                <text variable="page"/>
+            </else>
+        </choose>
     </macro>
     <macro name="serie">
         <choose>
@@ -173,7 +180,14 @@
                     <text macro="editor"/>
                     <choose>
                         <if variable="volume">
-                            <text prefix="Bd. " variable="volume"/>
+                            <choose>
+                                <if is-numeric="volume">
+                                    <text prefix="Bd. " variable="volume"/>
+                                </if>
+                                <else>
+                                    <text variable="volume"/>
+                                </else>
+                            </choose>
                         </if>
                         <else-if variable="number-of-volumes">
                             <text variable="number-of-volumes" suffix=" Bde."/>


### PR DESCRIPTION
We can make use of the `is-numeric` check for both, volumes and page numbers. This is in particular useful for cases like MGG2:

volume: We can now set the `volume` field e.g. to 'Sachteil, Bd. 5', which will use the field as it is, while just writing '5' will automatically prefix it with 'Bd. '.

page numbers: We can set the page numbers to something like `Sp. X-Y`, while a normal range `X-Y` will still prefix it with `S. `. (Conveniently, page ranges are also detected as numeric.)

@thomasxhua Any comments? :-) 